### PR TITLE
Namespace: v2 and v3, new variables' API with clear namespace 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v3.0.0](https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/tree/v3.0.0)
+
+* End of v1.0.0 variables' API backward's compatibility, no longer needed and not considered clean code
+
 ## [v2.0.0](https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/tree/v2.0.0)
 
 * New role's variables interface, with a uniform namespace pve_kvm_*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [v2.0.0](https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/tree/v2.0.0)
+
+* New role's variables interface, with a uniform namespace pve_kvm_*
+* Now possible to define the proxmox hostname as a variable, `pve_kvm_hostname`
+
 ## [v1.2.0](https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/tree/v1.2.0)
 
 * Added variable to parameterize proxmox_kvm module timeout

--- a/README.md
+++ b/README.md
@@ -35,10 +35,7 @@ Role Variables
 
 The `defaults` variables define the VM parameters. To be specified by host under `host_vars/host_fqdn/vars` and eventually encrypted in `host_vars/host_fqdn/vault`
 
-New interface in v2.0.0, with all role variables defined in the `pve_kvm_*` namespace. Update your host variables in your ansible code!
-
-To give time to update your whole inventory, the role preserves backward compatibility with [previous interface](https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/blob/v1.2.0/README.md#role-variables) up to v3.X.Y release. 
-
+New interface introduced in v2.0.0 is maintained, with role's variables defined in the `pve_*` namespace when they are shared between several Proxmox roles, and in the `pve_kvm_*` namespace when they are specific to th present one. The role is no longer backward's compatible with [v1.X.Y previous interface](https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/blob/v1.2.0/README.md#role-variables). 
 
 ```yaml
 pve_hostname: "{{ inventory_hostname.split('.')[0] }}"
@@ -80,37 +77,37 @@ pve_kvm_vga: std      # Select VGA type. If you want to use high resolution mode
               # Choices: std (default) - cirrus - vmware - qxl - serial0 - serial1 - serial2 - serial3 - qxl2 - qxl3 - qxl4
 
 pve_kvm_hard_disks:
-  - id: 0                         #  0 ≤ n ≤ 15
-    bus: virtio                   # Optional. Available buses: virtio (default) - ide - sata - scsi
-    storage: local-lvm
-    size: 32
-    format: raw                   # Optional. Available formats: qcow2 - raw (default) - subvol
-    backup: true                  # Optional
-    skip_replication: false       # Optional
-    cache: none                   # Optional. Available types: none (default) - directsync - writethrough - writeback - unsafe
-    io_thread: false              # Optional
-    ssd_emulation: false          # Optional
+- id: 0                         #  0 ≤ n ≤ 15
+  bus: virtio                   # Optional. Available buses: virtio (default) - ide - sata - scsi
+  storage: local-lvm
+  size: 32
+  format: raw                   # Optional. Available formats: qcow2 - raw (default) - subvol
+  backup: true                  # Optional
+  skip_replication: false       # Optional
+  cache: none                   # Optional. Available types: none (default) - directsync - writethrough - writeback - unsafe
+  io_thread: false              # Optional
+  ssd_emulation: false          # Optional
 
-  - id: 1
-    bus: sata
-    storage: local-lvm
-    size: 16
-    ssd_emulation: true
-    backup: false
+- id: 1
+  bus: sata
+  storage: local-lvm
+  size: 16
+  ssd_emulation: true
+  backup: false
 
 pve_kvm_net_interfaces:
-  - id: net0
-    model: virtio                 # Optional. Available models: virtio - e1000 - rtl8139 - vmxnet3
-    hwaddr: 46:70:B7:26:87:4F     # Optional. If not indicated, Proxmox will assign one automatically.
-    bridge: vmbr0
-    firewall: true                # Optional
-    disconnect: true              # Optional
-    multiqueue: 2                 # Optional
-    rate_limit: 250               # Optional (In MB/s)
-    vlan_tag: 400                 # Optional
+- id: net0
+  model: virtio                 # Optional. Available models: virtio - e1000 - rtl8139 - vmxnet3
+  hwaddr: 46:70:B7:26:87:4F     # Optional. If not indicated, Proxmox will assign one automatically.
+  bridge: vmbr0
+  firewall: true                # Optional
+  disconnect: true              # Optional
+  multiqueue: 2                 # Optional
+  rate_limit: 250               # Optional (In MB/s)
+  vlan_tag: 400                 # Optional
 
-  - id: net1
-    bridge: vmbr0
+- id: net1
+  bridge: vmbr0
 ```
 
 Dependencies

--- a/README.md
+++ b/README.md
@@ -35,43 +35,48 @@ Role Variables
 
 The `defaults` variables define the VM parameters. To be specified by host under `host_vars/host_fqdn/vars` and eventually encrypted in `host_vars/host_fqdn/vault`
 
-```yaml
-node: my_node
-api_host: my_node.my_cluster.org
-api_user: deploy@pam
-api_password: "pass1234" ## Better put passwords in a vault, ex. [group_vars | host_vars]/{{ inventory_hostname }}/vault/main.yml
-node_deploy_password: D3pl0y_pwd
+New interface in v2.0.0, with all role variables defined in the `pve_kvm_*` namespace. Update your host variables in your ansible code!
 
-start_after_create: false # Turn on the VM once created. Whether created from scratch or cloned
-pve_timeout: 500 # Timeout (in seconds) for operations, both clone and create
+To give time to update your whole inventory, the role preserves backward compatibility with [previous interface](https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/blob/v1.2.0/README.md#role-variables) up to v3.X.Y release. 
+
+
+```yaml
+pve_kvm_node: my_node
+pve_kvm_api_host: my_node.my_cluster.org
+pve_kvm_api_user: deploy@pam
+pve_kvm_api_password: "pass1234" ## Better put passwords in a vault, ex. [group_vars | host_vars]/{{ inventory_hostname }}/vault/main.yml
+pve_kvm_node_deploy_password: D3pl0y_pwd
+
+pve_kvm_start_after_create: false # Turn on the VM once created. Whether created from scratch or cloned
+pve_kvm_timeout: 500 # Timeout (in seconds) for operations, both clone and create
 
 # If the VM is cloned, the other parameters are not used, the assigned hardware characteristics are inherited from the cloned VM
-clone_from_existing: false        # FALSE: create a new VM  -  TRUE: clone an existing VM
-full_clone: true                  # FALSE: linked clone  -  TRUE: full clone ## See https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/issues/2
-clone_vm: DebianBusterTemplate    # The VM to clone
-clone_storage: local-lvm          # Target storage for full clone.
-clone_format: raw                 # Target drive's backing file's data format. Used only with clone
-                                  # Choices: cloop - cow - qcow - qcow2 (default) - qed - raw - vmdk
-clone_target: "{{ node }}"        # Target node
-# clone_vmid: 1                   # VM source id
-# clone_newid: 9                  # Clone id
+pve_kvm_clone_from_existing: false        # FALSE: create a new VM  -  TRUE: clone an existing VM
+pve_kvm_full_clone: true                  # FALSE: linked clone  -  TRUE: full clone ## See https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/issues/2
+pve_kvm_clone_vm: DebianBusterTemplate    # The VM to clone
+pve_kvm_clone_storage: local-lvm          # Target storage for full clone.
+pve_kvm_clone_format: raw                 # Target drive's backing file's data format. Used only with clone
+                                          # Choices: cloop - cow - qcow - qcow2 (default) - qed - raw - vmdk
+pve_kvm_clone_target: "{{ pve_kvm_node }}"        # Target node
+# pve_kvm_clone_vmid: 1                   # VM source id
+# pve_kvm_clone_newid: 9                  # Clone id
                                   # Choices: cloop - cow - qcow - qcow2 (default) - qed - raw - vmdk
 
-description: LAMP Server
-kvm: yes
-ostype: l26   # Choices: l24 - l26 (default) - other - wxp - w2k - w2k3 - w2k8 - wvista - win7 - win8 - solaris
+pve_kvm_description: LAMP Server
+pve_kvm_kvm: yes
+pve_kvm_ostype: l26   # Choices: l24 - l26 (default) - other - wxp - w2k - w2k3 - w2k8 - wvista - win7 - win8 - solaris
 
-sockets: 1
-cores: 1
-cpuunits: 1000
-cpulimit: 0
-memory: 512
-balloon: 0
-shares: 0     # Amount of memory shares for auto-ballooning. (0 - 50000). Using 0 disables auto-ballooning, this means no limit.
-vga: std      # Select VGA type. If you want to use high resolution modes (>= 1280x1024x16) then you should use option 'std' or 'vmware'.
+pve_kvm_sockets: 1
+pve_kvm_cores: 1
+pve_kvm_cpuunits: 1000
+pve_kvm_cpulimit: 0
+pve_kvm_memory: 512
+pve_kvm_balloon: 0
+pve_kvm_shares: 0     # Amount of memory shares for auto-ballooning. (0 - 50000). Using 0 disables auto-ballooning, this means no limit.
+pve_kvm_vga: std      # Select VGA type. If you want to use high resolution modes (>= 1280x1024x16) then you should use option 'std' or 'vmware'.
               # Choices: std (default) - cirrus - vmware - qxl - serial0 - serial1 - serial2 - serial3 - qxl2 - qxl3 - qxl4
 
-hard_disks:
+pve_kvm_hard_disks:
   - id: 0                         #  0 ≤ n ≤ 15
     bus: virtio                   # Optional. Available buses: virtio (default) - ide - sata - scsi
     storage: local-lvm
@@ -90,7 +95,7 @@ hard_disks:
     ssd_emulation: true
     backup: false
 
-net_interfaces:
+pve_kvm_net_interfaces:
   - id: net0
     model: virtio                 # Optional. Available models: virtio - e1000 - rtl8139 - vmxnet3
     hwaddr: 46:70:B7:26:87:4F     # Optional. If not indicated, Proxmox will assign one automatically.

--- a/README.md
+++ b/README.md
@@ -41,11 +41,14 @@ To give time to update your whole inventory, the role preserves backward compati
 
 
 ```yaml
-pve_kvm_node: my_node
-pve_kvm_api_host: my_node.my_cluster.org
-pve_kvm_api_user: deploy@pam
-pve_kvm_api_password: "pass1234" ## Better put passwords in a vault, ex. [group_vars | host_vars]/{{ inventory_hostname }}/vault/main.yml
-pve_kvm_node_deploy_password: D3pl0y_pwd
+pve_hostname: "{{ inventory_hostname.split('.')[0] }}"
+# By default, we suppose that `inventory_hostname` is the FQDN or the hostname of the host to create, so we set the variable to the hostname. 
+# You can arbitrarly define this hostname
+
+pve_node: my_node
+pve_api_host: my_node.my_cluster.org
+pve_api_user: deploy@pam
+pve_api_password: "pass1234" ## Better put passwords in a vault, ex. [group_vars | host_vars]/{{ inventory_hostname }}/vault/main.yml
 
 pve_kvm_start_after_create: false # Turn on the VM once created. Whether created from scratch or cloned
 pve_kvm_timeout: 500 # Timeout (in seconds) for operations, both clone and create
@@ -57,7 +60,7 @@ pve_kvm_clone_vm: DebianBusterTemplate    # The VM to clone
 pve_kvm_clone_storage: local-lvm          # Target storage for full clone.
 pve_kvm_clone_format: raw                 # Target drive's backing file's data format. Used only with clone
                                           # Choices: cloop - cow - qcow - qcow2 (default) - qed - raw - vmdk
-pve_kvm_clone_target: "{{ pve_kvm_node }}"        # Target node
+pve_kvm_clone_target: "{{ pve_node }}"        # Target node
 # pve_kvm_clone_vmid: 1                   # VM source id
 # pve_kvm_clone_newid: 9                  # Clone id
                                   # Choices: cloop - cow - qcow - qcow2 (default) - qed - raw - vmdk

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,13 +3,12 @@
 # typical variables to define for a virtual machine (in host_vars/inventory_hostname, for ex.)
 
 # Proxmox hostname of the kvm to be created. By default, inventory_hostname is the FQDN or hostname, we set the hostname.
-pve_kvm_hostname: "{{ inventory_hostname.split('.')[0] }}"
+pve_hostname: "{{ inventory_hostname.split('.')[0] }}"
 
-pve_kvm_node: "{{ node if node is defined else 'my_node' }}"
-pve_kvm_api_host: "{{ api_host if api_host is defined else 'my_node.my_cluster.org' }}"
-pve_kvm_api_user: "{{ api_user if api_user is defined else 'deploy@pam' }}"
-pve_kvm_api_password: "{{ api_password if api_password is defined else 'pass1234' }}" ## Better put passwords in a vault, ex. [group_vars | host_vars]/{{ inventory_hostname }}/vault/main.yml
-pve_kvm_node_deploy_password: "{{ node_deploy_password if node_deploy_password is defined else 'D3pl0y_pwd' }}"
+pve_node: "{{ node if node is defined else 'my_node' }}"
+pve_api_host: "{{ api_host if api_host is defined else 'my_node.my_cluster.org' }}"
+pve_api_user: "{{ api_user if api_user is defined else 'deploy@pam' }}"
+pve_api_password: "{{ api_password if api_password is defined else 'pass1234' }}" ## Better put passwords in a vault, ex. [group_vars | host_vars]/{{ inventory_hostname }}/vault/main.yml
 
 pve_kvm_start_after_create: "{{ start_after_create if start_after_create is defined else 'false' }}" # Turn on the VM once created. Whether created from scratch or cloned
 pve_kvm_timeout: "{{ pve_timeout if pve_timeout is defined else '500' }}" # Timeout (in seconds) for operations, both clone and create
@@ -20,7 +19,7 @@ pve_kvm_full_clone: "{{ full_clone if full_clone is defined else 'true' }}"     
 pve_kvm_clone_vm: "{{ clone_vm if clone_vm is defined else 'DebianBusterTemplate' }}"    # The VM to clone
 pve_kvm_clone_storage: "{{ clone_storage if clone_storage is defined else 'local-lvm' }}"          # Target storage for full clone.
 pve_kvm_clone_format: "{{ clone_format if clone_format is defined else 'raw' }}"                 # Target drive's backing file's data format. Used only with clone
-pve_kvm_clone_target: "{{ pve_kvm_node }}"        # Target node
+pve_kvm_clone_target: "{{ pve_node }}"        # Target node
 # pve_kvm_clone_vmid: 1                   # VM source id
 # pve_kvm_clone_newid: 9                  # Clone id
                                   # Choices: cloop - cow - qcow - qcow2 (default) - qed - raw - vmdk

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,42 +2,46 @@
 # defaults file for ansible-role-proxmox-create-kvm/
 # typical variables to define for a virtual machine (in host_vars/inventory_hostname, for ex.)
 
-node: my_node
-api_host: my_node.my_cluster.org
-api_user: deploy@pam
-api_password: "pass1234" ## Better put passwords in a vault, ex. [group_vars | host_vars]/{{ inventory_hostname }}/vault/main.yml
-node_deploy_password: D3pl0y_pwd
+# Proxmox hostname of the kvm to be created. By default, inventory_hostname is the FQDN or hostname, we set the hostname.
+pve_kvm_hostname: "{{ inventory_hostname.split('.')[0] }}"
 
-start_after_create: false # Turn on the VM once created. Whether created from scratch or cloned
-pve_timeout: 500 # Timeout (in seconds) for operations, both clone and create
+pve_kvm_node: "{{ node if node is defined else 'my_node' }}"
+pve_kvm_api_host: "{{ api_host if api_host is defined else 'my_node.my_cluster.org' }}"
+pve_kvm_api_user: "{{ api_user if api_user is defined else 'deploy@pam' }}"
+pve_kvm_api_password: "{{ api_password if api_password is defined else 'pass1234' }}" ## Better put passwords in a vault, ex. [group_vars | host_vars]/{{ inventory_hostname }}/vault/main.yml
+pve_kvm_node_deploy_password: "{{ node_deploy_password if node_deploy_password is defined else 'D3pl0y_pwd' }}"
+
+pve_kvm_start_after_create: "{{ start_after_create if start_after_create is defined else 'false' }}" # Turn on the VM once created. Whether created from scratch or cloned
+pve_kvm_timeout: "{{ pve_timeout if pve_timeout is defined else '500' }}" # Timeout (in seconds) for operations, both clone and create
 
 # If the VM is cloned, the other parameters are not used, the assigned hardware characteristics are inherited from the cloned VM
-clone_from_existing: false        # FALSE: create a new VM  -  TRUE: clone an existing VM
-full_clone: true                  # FALSE: linked clone  -  TRUE: full clone ## See https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/issues/2
-clone_vm: DebianBusterTemplate    # The VM to clone
-clone_storage: local-lvm          # Target storage for full clone.
-clone_format: raw                 # Target drive's backing file's data format. Used only with clone
-clone_target: "{{ node }}"        # Target node
+pve_kvm_clone_from_existing: "{{ clone_from_existing if clone_from_existing is defined else 'false' }}"        # FALSE: create a new VM  -  TRUE: clone an existing VM
+pve_kvm_full_clone: "{{ full_clone if full_clone is defined else true'' }}"                  # FALSE: linked clone  -  TRUE: full clone ## See https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/issues/2
+pve_kvm_clone_vm: "{{ clone_vm if clone_vm is defined else 'DebianBusterTemplate' }}"    # The VM to clone
+pve_kvm_clone_storage: "{{ clone_storage if clone_storage is defined else 'local-lvm' }}"          # Target storage for full clone.
+pve_kvm_clone_format: "{{ clone_format if clone_format is defined else 'raw' }}"                 # Target drive's backing file's data format. Used only with clone
+pve_kvm_clone_target: "{{ pve_kvm_node }}"        # Target node
 # clone_vmid: 1                   # VM source id
 # clone_newid: 9                  # Clone id
                                   # Choices: cloop - cow - qcow - qcow2 (default) - qed - raw - vmdk
 
 
-description: LAMP Server
-kvm: yes
-ostype: l26   # Choices: l24 - l26 (default) - other - wxp - w2k - w2k3 - w2k8 - wvista - win7 - win8 - solaris
+pve_kvm_description: "{{ description if description is defined else 'LAMP Server' }}"
+pve_kvm_kvm: "{{ kvm if kvm is defined else 'yes' }}"
+pve_kvm_ostype: "{{ ostype if ostype is defined else 'l26' }}"   # Choices: l24 - l26 (default) - other - wxp - w2k - w2k3 - w2k8 - wvista - win7 - win8 - solaris
 
-sockets: 1
-cores: 1
-cpuunits: 1000
-cpulimit: 0
-memory: 512
-balloon: 0
-shares: 0     # Amount of memory shares for auto-ballooning. (0 - 50000). Using 0 disables auto-ballooning, this means no limit.
-vga: std      # Select VGA type. If you want to use high resolution modes (>= 1280x1024x16) then you should use option 'std' or 'vmware'.
+pve_kvm_sockets: "{{ sockets if sockets is defined else '1' }}"
+pve_kvm_cores: "{{ cores if cores is defined else '1' }}"
+pve_kvm_cpuunits: "{{ cpuunits if cpuunits is defined else '1000' }}"
+pve_kvm_cpulimit: "{{ cpulimit if cpulimit is defined else '0' }}"
+pve_kvm_memory: "{{ memory if memory is defined else '512' }}"
+pve_kvm_balloon: "{{ balloon if balloon is defined else '0' }}"
+pve_kvm_shares: "{{ shares if shares is defined else '0' }}"     # Amount of memory shares for auto-ballooning. (0 - 50000). Using 0 disables auto-ballooning, this means no limit.
+pve_kvm_vga: "{{ vga if vga is defined else 'std' }}"      # Select VGA type. If you want to use high resolution modes (>= 1280x1024x16) then you should use option 'std' or 'vmware'.
               # Choices: std (default) - cirrus - vmware - qxl - serial0 - serial1 - serial2 - serial3 - qxl2 - qxl3 - qxl4
 
-hard_disks:
+pve_kvm_hard_disks: "{{ hard_disks if hard_disks is defined else pve_kvm_hard_disks_default }}"
+pve_kvm_hard_disks_default:
   - id: 0                         #  0 ≤ n ≤ 15
     bus: virtio                   # Optional. Available buses: virtio (default) - ide - sata - scsi
     storage: local-lvm
@@ -56,8 +60,8 @@ hard_disks:
     ssd_emulation: true
     backup: false
 
-
-net_interfaces:
+pve_kvm_net_interfaces: "{{ net_interfaces if net_interfaces is defined else pve_kvm_net_interfaces_default }}"
+pve_kvm_net_interfaces_default:
   - id: net0
     model: virtio                 # Optional. Available models: virtio - e1000 - rtl8139 - vmxnet3
     hwaddr: 46:70:B7:26:87:4F     # Optional. If not indicated, Proxmox will assign one automatically.
@@ -70,3 +74,5 @@ net_interfaces:
 
   - id: net1
     bridge: vmbr0
+
+...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ pve_kvm_timeout: "{{ pve_timeout if pve_timeout is defined else '500' }}" # Time
 
 # If the VM is cloned, the other parameters are not used, the assigned hardware characteristics are inherited from the cloned VM
 pve_kvm_clone_from_existing: "{{ clone_from_existing if clone_from_existing is defined else 'false' }}"        # FALSE: create a new VM  -  TRUE: clone an existing VM
-pve_kvm_full_clone: "{{ full_clone if full_clone is defined else true'' }}"                  # FALSE: linked clone  -  TRUE: full clone ## See https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/issues/2
+pve_kvm_full_clone: "{{ full_clone if full_clone is defined else 'true' }}"                  # FALSE: linked clone  -  TRUE: full clone ## See https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/issues/2
 pve_kvm_clone_vm: "{{ clone_vm if clone_vm is defined else 'DebianBusterTemplate' }}"    # The VM to clone
 pve_kvm_clone_storage: "{{ clone_storage if clone_storage is defined else 'local-lvm' }}"          # Target storage for full clone.
 pve_kvm_clone_format: "{{ clone_format if clone_format is defined else 'raw' }}"                 # Target drive's backing file's data format. Used only with clone

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,73 +5,75 @@
 # Proxmox hostname of the kvm to be created. By default, inventory_hostname is the FQDN or hostname, we set the hostname.
 pve_hostname: "{{ inventory_hostname.split('.')[0] }}"
 
-pve_node: "{{ node if node is defined else 'my_node' }}"
-pve_api_host: "{{ api_host if api_host is defined else 'my_node.my_cluster.org' }}"
-pve_api_user: "{{ api_user if api_user is defined else 'deploy@pam' }}"
-pve_api_password: "{{ api_password if api_password is defined else 'pass1234' }}" ## Better put passwords in a vault, ex. [group_vars | host_vars]/{{ inventory_hostname }}/vault/main.yml
+# proxmox node where we create or manage an LXC container
+pve_node: my_node
+# api_host: Proxmox API DNS or IP where we manage the Proxmox cluster or node 
+pve_api_host: my_node.my_cluster.org
+# api_user: User to connect to the Proxmox cluster API
+pve_api_user: deploy@pam
+# Password for the previous API user
+## Better put this in a vault, ex. [group_vars | host_vars]/{{ inventory_hostname }}/vault/main.yml
+## This dummy example can only cause an error.
+pve_api_password: pass1234 
 
-pve_kvm_start_after_create: "{{ start_after_create if start_after_create is defined else 'false' }}" # Turn on the VM once created. Whether created from scratch or cloned
-pve_kvm_timeout: "{{ pve_timeout if pve_timeout is defined else '500' }}" # Timeout (in seconds) for operations, both clone and create
-
+pve_kvm_start_after_create: false # Turn on the VM once created. Whether created from scratch or cloned
+pve_kvm_timeout: 500 # Timeout (in seconds) for operations, both clone and create
 # If the VM is cloned, the other parameters are not used, the assigned hardware characteristics are inherited from the cloned VM
-pve_kvm_clone_from_existing: "{{ clone_from_existing if clone_from_existing is defined else 'false' }}"        # FALSE: create a new VM  -  TRUE: clone an existing VM
-pve_kvm_full_clone: "{{ full_clone if full_clone is defined else 'true' }}"                  # FALSE: linked clone  -  TRUE: full clone ## See https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/issues/2
-pve_kvm_clone_vm: "{{ clone_vm if clone_vm is defined else 'DebianBusterTemplate' }}"    # The VM to clone
-pve_kvm_clone_storage: "{{ clone_storage if clone_storage is defined else 'local-lvm' }}"          # Target storage for full clone.
-pve_kvm_clone_format: "{{ clone_format if clone_format is defined else 'raw' }}"                 # Target drive's backing file's data format. Used only with clone
-pve_kvm_clone_target: "{{ pve_node }}"        # Target node
+pve_kvm_clone_from_existing: false        # FALSE: create a new VM  -  TRUE: clone an existing VM
+pve_kvm_full_clone: true                  # FALSE: linked clone  -  TRUE: full clone ## See https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/issues/2
+pve_kvm_clone_vm: DebianBusterTemplate    # The VM to clone
+pve_kvm_clone_storage: local-lvm          # Target storage for full clone.
+pve_kvm_clone_format: raw                 # Target drive's backing file's data format. Used only with clone
+                                          # Choices: cloop - cow - qcow - qcow2 (default) - qed - raw - vmdk
+pve_kvm_clone_target: "{{ pve_node }}"    # Target node
 # pve_kvm_clone_vmid: 1                   # VM source id
 # pve_kvm_clone_newid: 9                  # Clone id
-                                  # Choices: cloop - cow - qcow - qcow2 (default) - qed - raw - vmdk
 
+pve_kvm_description: LAMP Server
+pve_kvm_kvm: yes
+pve_kvm_ostype: l26   # Choices: l24 - l26 (default) - other - wxp - w2k - w2k3 - w2k8 - wvista - win7 - win8 - solaris
 
-pve_kvm_description: "{{ description if description is defined else 'LAMP Server' }}"
-pve_kvm_kvm: "{{ kvm if kvm is defined else 'yes' }}"
-pve_kvm_ostype: "{{ ostype if ostype is defined else 'l26' }}"   # Choices: l24 - l26 (default) - other - wxp - w2k - w2k3 - w2k8 - wvista - win7 - win8 - solaris
+pve_kvm_sockets: 1
+pve_kvm_cores: 1
+pve_kvm_cpuunits: 1000
+pve_kvm_cpulimit: 0
+pve_kvm_memory: 512
+pve_kvm_balloon: 0
+pve_kvm_shares: 0     # Amount of memory shares for auto-ballooning. (0 - 50000). Using 0 disables auto-ballooning, this means no limit.
+pve_kvm_vga: std      # Select VGA type. If you want to use high resolution modes (>= 1280x1024x16) then you should use option 'std' or 'vmware'.
+                      # Choices: std (default) - cirrus - vmware - qxl - serial0 - serial1 - serial2 - serial3 - qxl2 - qxl3 - qxl4
 
-pve_kvm_sockets: "{{ sockets if sockets is defined else '1' }}"
-pve_kvm_cores: "{{ cores if cores is defined else '1' }}"
-pve_kvm_cpuunits: "{{ cpuunits if cpuunits is defined else '1000' }}"
-pve_kvm_cpulimit: "{{ cpulimit if cpulimit is defined else '0' }}"
-pve_kvm_memory: "{{ memory if memory is defined else '512' }}"
-pve_kvm_balloon: "{{ balloon if balloon is defined else '0' }}"
-pve_kvm_shares: "{{ shares if shares is defined else '0' }}"     # Amount of memory shares for auto-ballooning. (0 - 50000). Using 0 disables auto-ballooning, this means no limit.
-pve_kvm_vga: "{{ vga if vga is defined else 'std' }}"      # Select VGA type. If you want to use high resolution modes (>= 1280x1024x16) then you should use option 'std' or 'vmware'.
-              # Choices: std (default) - cirrus - vmware - qxl - serial0 - serial1 - serial2 - serial3 - qxl2 - qxl3 - qxl4
+pve_kvm_hard_disks: 
+- id: 0                         #  0 ≤ n ≤ 15
+  bus: virtio                   # Optional. Available buses: virtio (default) - ide - sata - scsi
+  storage: local-lvm
+  size: 32
+  format: raw                   # Optional. Available formats: qcow2 - raw (default) - subvol
+  backup: true                  # Optional
+  skip_replication: false       # Optional
+  cache: none                   # Optional. Available types: none (default) - directsync - writethrough - writeback - unsafe
+  io_thread: false              # Optional
+  ssd_emulation: false          # Optional
 
-pve_kvm_hard_disks: "{{ hard_disks if hard_disks is defined else pve_kvm_hard_disks_default }}"
-pve_kvm_hard_disks_default:
-  - id: 0                         #  0 ≤ n ≤ 15
-    bus: virtio                   # Optional. Available buses: virtio (default) - ide - sata - scsi
-    storage: local-lvm
-    size: 32
-    format: raw                   # Optional. Available formats: qcow2 - raw (default) - subvol
-    backup: true                  # Optional
-    skip_replication: false       # Optional
-    cache: none                   # Optional. Available types: none (default) - directsync - writethrough - writeback - unsafe
-    io_thread: false              # Optional
-    ssd_emulation: false          # Optional
+- id: 1
+  bus: sata
+  storage: local-lvm
+  size: 16
+  ssd_emulation: true
+  backup: false
 
-  - id: 1
-    bus: sata
-    storage: local-lvm
-    size: 16
-    ssd_emulation: true
-    backup: false
+pve_kvm_net_interfaces:
+- id: net0
+  model: virtio                 # Optional. Available models: virtio - e1000 - rtl8139 - vmxnet3
+  hwaddr: 46:70:B7:26:87:4F     # Optional. If not indicated, Proxmox will assign one automatically.
+  bridge: vmbr0
+  firewall: true                # Optional
+  disconnect: true              # Optional
+  multiqueue: 2                 # Optional
+  rate_limit: 250               # Optional (In MB/s)
+  vlan_tag: 400                 # Optional
 
-pve_kvm_net_interfaces: "{{ net_interfaces if net_interfaces is defined else pve_kvm_net_interfaces_default }}"
-pve_kvm_net_interfaces_default:
-  - id: net0
-    model: virtio                 # Optional. Available models: virtio - e1000 - rtl8139 - vmxnet3
-    hwaddr: 46:70:B7:26:87:4F     # Optional. If not indicated, Proxmox will assign one automatically.
-    bridge: vmbr0
-    firewall: true                # Optional
-    disconnect: true              # Optional
-    multiqueue: 2                 # Optional
-    rate_limit: 250               # Optional (In MB/s)
-    vlan_tag: 400                 # Optional
-
-  - id: net1
-    bridge: vmbr0
+- id: net1
+  bridge: vmbr0
 
 ...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,8 +21,8 @@ pve_kvm_clone_vm: "{{ clone_vm if clone_vm is defined else 'DebianBusterTemplate
 pve_kvm_clone_storage: "{{ clone_storage if clone_storage is defined else 'local-lvm' }}"          # Target storage for full clone.
 pve_kvm_clone_format: "{{ clone_format if clone_format is defined else 'raw' }}"                 # Target drive's backing file's data format. Used only with clone
 pve_kvm_clone_target: "{{ pve_kvm_node }}"        # Target node
-# clone_vmid: 1                   # VM source id
-# clone_newid: 9                  # Clone id
+# pve_kvm_clone_vmid: 1                   # VM source id
+# pve_kvm_clone_newid: 9                  # Clone id
                                   # Choices: cloop - cow - qcow - qcow2 (default) - qed - raw - vmdk
 
 

--- a/tasks/clone_kvm.yml
+++ b/tasks/clone_kvm.yml
@@ -3,18 +3,18 @@
 # Crear una KVM clonando un VM template Proxmox preexistente
 - name: Create a KVM by cloning a pre-existing Proxmox VM template
   proxmox_kvm:
-    node: "{{ node }}"
-    api_user: "{{ api_user }}"
-    api_host: "{{ api_host }}"
-    api_password: "{{ api_password }}"
-    name: "{{ proxmox_hostname }}"
-    clone: "{{ clone_vm | default (omit) }}"            # The VM source
-    full: "{{ full_clone | default (omit) }}"
-    storage:  "{{ clone_storage | default (omit) }}"    # Target storage for full clone.
-    format: "{{ clone_format | default (omit) }}"       # Target drive's backing file's data format. Used only with clone
-    timeout: "{{ pve_timeout }}"                      # Cloning can take a while
-    target: "{{ clone_target }}"                        # Target node
-    vmid: "{{ clone_vmid | default (omit) }}"           # VM source id
-    newid: "{{ clone_newid | default (omit) }}"         # Clone id
-  register: virtualm
-  delegate_to: "{{ api_host }}"
+    node: "{{ pve_kvm_node }}"
+    api_user: "{{ pve_kvm_api_user }}"
+    api_host: "{{ pve_kvm_api_host }}"
+    api_password: "{{ pve_kvm_api_password }}"
+    name: "{{ pve_kvm_hostname }}"
+    clone: "{{ pve_kvm_clone_vm | default (omit) }}"            # The VM source
+    full: "{{ pve_kvm_full_clone | default (omit) }}"
+    storage:  "{{ pve_kvm_clone_storage | default (omit) }}"    # Target storage for full clone.
+    format: "{{ pve_kvm_clone_format | default (omit) }}"       # Target drive's backing file's data format. Used only with clone
+    timeout: "{{ pve_kvm_timeout }}"                      # Cloning can take a while
+    target: "{{ pve_kvm_clone_target }}"                        # Target node
+    vmid: "{{ pve_kvm_clone_vmid | default (omit) }}"           # VM source id
+    newid: "{{ pve_kvm_clone_newid | default (omit) }}"         # Clone id
+  register: pve_kvm_virtualm
+  delegate_to: "{{ pve_kvm_api_host }}"

--- a/tasks/clone_kvm.yml
+++ b/tasks/clone_kvm.yml
@@ -18,3 +18,5 @@
     newid: "{{ pve_kvm_clone_newid | default (omit) }}"         # Clone id
   register: pve_kvm_virtualm
   delegate_to: "{{ pve_kvm_api_host }}"
+
+...

--- a/tasks/clone_kvm.yml
+++ b/tasks/clone_kvm.yml
@@ -3,11 +3,11 @@
 # Crear una KVM clonando un VM template Proxmox preexistente
 - name: Create a KVM by cloning a pre-existing Proxmox VM template
   proxmox_kvm:
-    node: "{{ pve_kvm_node }}"
-    api_user: "{{ pve_kvm_api_user }}"
-    api_host: "{{ pve_kvm_api_host }}"
-    api_password: "{{ pve_kvm_api_password }}"
-    name: "{{ pve_kvm_hostname }}"
+    node: "{{ pve_node }}"
+    api_user: "{{ pve_api_user }}"
+    api_host: "{{ pve_api_host }}"
+    api_password: "{{ pve_api_password }}"
+    name: "{{ pve_hostname }}"
     clone: "{{ pve_kvm_clone_vm | default (omit) }}"            # The VM source
     full: "{{ pve_kvm_full_clone | default (omit) }}"
     storage:  "{{ pve_kvm_clone_storage | default (omit) }}"    # Target storage for full clone.
@@ -17,6 +17,6 @@
     vmid: "{{ pve_kvm_clone_vmid | default (omit) }}"           # VM source id
     newid: "{{ pve_kvm_clone_newid | default (omit) }}"         # Clone id
   register: pve_kvm_virtualm
-  delegate_to: "{{ pve_kvm_api_host }}"
+  delegate_to: "{{ pve_api_host }}"
 
 ...

--- a/tasks/create_kvm.yml
+++ b/tasks/create_kvm.yml
@@ -3,14 +3,14 @@
 # Crear una KVM desde cero en el nodo Proxmox
 - name: Create a KVM from scratch in Proxmox node
   proxmox_kvm:
-    node: "{{ pve_kvm_node }}"
-    api_user: "{{ pve_kvm_api_user }}"
-    api_host: "{{ pve_kvm_api_host }}"
-    api_password: "{{ pve_kvm_api_password }}"
+    node: "{{ pve_node }}"
+    api_user: "{{ pve_api_user }}"
+    api_host: "{{ pve_api_host }}"
+    api_password: "{{ pve_api_password }}"
     description: "{{ pve_kvm_description | default (omit) }}"
     kvm: "{{ pve_kvm_kvm | default (omit) }}"
     ostype: "{{ pve_kvm_ostype | default (omit) }}"
-    name: "{{ pve_kvm_hostname }}"
+    name: "{{ pve_hostname }}"
     sockets: "{{ pve_kvm_sockets | default (omit) }}"
     cores: "{{ pve_kvm_cores | default (omit) }}"
     cpuunits: "{{ pve_kvm_cpuunits | default (omit) }}"
@@ -30,6 +30,6 @@
           {%- endfor -%}  }
 
   register: pve_kvm_virtualm
-  delegate_to: "{{ pve_kvm_api_host }}"
+  delegate_to: "{{ pve_api_host }}"
 
 ...

--- a/tasks/create_kvm.yml
+++ b/tasks/create_kvm.yml
@@ -3,31 +3,31 @@
 # Crear una KVM desde cero en el nodo Proxmox
 - name: Create a KVM from scratch in Proxmox node
   proxmox_kvm:
-    node: "{{ node }}"
-    api_user: "{{ api_user }}"
-    api_host: "{{ api_host }}"
-    api_password: "{{ api_password }}"
-    description: "{{ description | default (omit) }}"
-    kvm: "{{ kvm | default (omit) }}"
-    ostype: "{{ ostype | default (omit) }}"
-    name: "{{ proxmox_hostname }}"
-    sockets: "{{ sockets | default (omit) }}"
-    cores: "{{ cores | default (omit) }}"
-    cpuunits: "{{ cpuunits | default (omit) }}"
-    cpulimit: "{{ cpulimit | default (omit) }}"
-    memory: "{{ memory | default (omit) }}"
-    timeout: "{{ pve_timeout }}"
-    balloon: "{{ balloon | default (omit) }}"
-    shares: "{{ shares | default (omit) }}"
-    vga: "{{ vga | default (omit) }}"
+    node: "{{ pve_kvm_node }}"
+    api_user: "{{ pve_kvm_api_user }}"
+    api_host: "{{ pve_kvm_api_host }}"
+    api_password: "{{ pve_kvm_api_password }}"
+    description: "{{ pve_kvm_description | default (omit) }}"
+    kvm: "{{ pve_kvm_kvm | default (omit) }}"
+    ostype: "{{ pve_kvm_ostype | default (omit) }}"
+    name: "{{ pve_kvm_hostname }}"
+    sockets: "{{ pve_kvm_sockets | default (omit) }}"
+    cores: "{{ pve_kvm_cores | default (omit) }}"
+    cpuunits: "{{ pve_kvm_cpuunits | default (omit) }}"
+    cpulimit: "{{ pve_kvm_cpulimit | default (omit) }}"
+    memory: "{{ pve_kvm_memory | default (omit) }}"
+    timeout: "{{ pve_kvm_timeout }}"
+    balloon: "{{ pve_kvm_balloon | default (omit) }}"
+    shares: "{{ pve_kvm_shares | default (omit) }}"
+    vga: "{{ pve_kvm_vga | default (omit) }}"
     virtio: >-
-      {   {%- for item in hard_disks -%}
+      {   {%- for item in pve_kvm_hard_disks -%}
             "{{ item.bus }}{{ item.id }}":"{{ item.storage }}:{{ item.size }},{% if item.format is defined %}format={{ item.format }},{% endif %}{% if (item.backup is defined and not item.backup) %}backup=0,{% endif %}{% if (item.skip_replication is defined and item.skip_replication) %}replicate=0,{% endif %}{% if item.cache is defined %}cache={{ item.cache }},{% endif %}{% if (item.io_thread is defined and item.io_thread) %}iothread=1,{% endif %}{% if (item.ssd_emulation is defined and item.ssd_emulation) %}ssd=1{% endif %}",
           {%- endfor -%}  }
     net: >-
-      {   {%- for item in net_interfaces -%}
+      {   {%- for item in pve_kvm_net_interfaces -%}
             "{{ item.id }}":"{% if item.model is defined %}{{ item.model }}{% else %}virtio{% endif %}{% if item.hwaddr is defined %}={{ item.hwaddr }}{% endif %},bridge={{ item.bridge }},{% if (item.firewall is defined and item.firewall) %}firewall=1,{% endif %}{% if (item.disconnect is defined and item.disconnect) %}link_down=1,{% endif %}{% if item.multiqueue is defined %}queues=1,{% endif %}{% if item.rate_limit is defined %}rate={{ item.rate_limit }},{% endif %}{% if item.vlan_tag is defined %}tag={{ item.vlan_tag }}{% endif %}",
           {%- endfor -%}  }
 
-  register: virtualm
-  delegate_to: "{{ api_host }}"
+  register: pve_kvm_virtualm
+  delegate_to: "{{ pve_kvm_api_host }}"

--- a/tasks/create_kvm.yml
+++ b/tasks/create_kvm.yml
@@ -31,3 +31,5 @@
 
   register: pve_kvm_virtualm
   delegate_to: "{{ pve_kvm_api_host }}"
+
+...

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -5,13 +5,13 @@
   apt:
     name: python-pip
     state: present
-  delegate_to: "{{ api_host }}"
+  delegate_to: "{{ pve_api_host }}"
 
 #  Verificar si el módulo proxmoxer de python está instalado
 - name: Verify if proxmoxer pip module is installed
   pip:
     name: proxmoxer
     state: present
-  delegate_to: "{{ api_host }}"
+  delegate_to: "{{ pve_api_host }}"
 
 ...

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,9 +1,5 @@
 ---
 
-# Extraer el hostname del inventory_hostname (debe ser el fqdn)
-- name: Extract hostname from inventory_hostname (must be fqdn)
-  set_fact:
-
 # Verificar si python-pip está instalado en el nodo proxmox
 - name: Verify that python-pip is installed in the Proxmox node
   apt:

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -3,7 +3,6 @@
 # Extraer el hostname del inventory_hostname (debe ser el fqdn)
 - name: Extract hostname from inventory_hostname (must be fqdn)
   set_fact:
-    proxmox_hostname: "{{ inventory_hostname.split('.')[0] }}"
 
 # Verificar si python-pip está instalado en el nodo proxmox
 - name: Verify that python-pip is installed in the Proxmox node

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -17,3 +17,5 @@
     name: proxmoxer
     state: present
   delegate_to: "{{ api_host }}"
+
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,22 +14,22 @@
 - name: Extract the ID of the VM
   shell: |
     set -o pipefail
-    qm list | grep -w "{{ proxmox_hostname }}" | awk '{ print $1 }'
+    qm list | grep -w "{{ pve_kvm_hostname }}" | awk '{ print $1 }'
   args:
     executable: /bin/bash
-  delegate_to: "{{ api_host }}"
+  delegate_to: "{{ pve_kvm_api_host }}"
   register: VMID
-  when: virtualm is succeeded
+  when: pve_kvm_virtualm is succeeded
   changed_when: false
 
 # Encender la VM
 - name: Turn on the VM
   proxmox_kvm:
-    node: "{{ node }}"
-    api_user: "{{ api_user }}"
-    api_host: "{{ api_host }}"
-    api_password: "{{ api_password }}"
-    vmid: "{{ VMID.stdout }}"
+    node: "{{ pve_kvm_node }}"
+    api_user: "{{ pve_kvm_api_user }}"
+    api_host: "{{ pve_kvm_api_host }}"
+    api_password: "{{ pve_kvm_api_password }}"
+    vmid: "{{ pve_kvm_VMID.stdout }}"
     state: started
-  delegate_to: "{{ api_host }}"
-  when: start_after_create | bool
+  delegate_to: "{{ pve_kvm_api_host }}"
+  when: pve_kvm_start_after_create | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,10 +14,10 @@
 - name: Extract the ID of the VM
   shell: |
     set -o pipefail
-    qm list | grep -w "{{ pve_kvm_hostname }}" | awk '{ print $1 }'
+    qm list | grep -w "{{ pve_hostname }}" | awk '{ print $1 }'
   args:
     executable: /bin/bash
-  delegate_to: "{{ pve_kvm_api_host }}"
+  delegate_to: "{{ pve_api_host }}"
   register: pve_kvm_VMID
   when: pve_kvm_virtualm is succeeded
   changed_when: false
@@ -25,13 +25,13 @@
 # Encender la VM
 - name: Turn on the VM
   proxmox_kvm:
-    node: "{{ pve_kvm_node }}"
-    api_user: "{{ pve_kvm_api_user }}"
-    api_host: "{{ pve_kvm_api_host }}"
-    api_password: "{{ pve_kvm_api_password }}"
+    node: "{{ pve_node }}"
+    api_user: "{{ pve_api_user }}"
+    api_host: "{{ pve_api_host }}"
+    api_password: "{{ pve_api_password }}"
     vmid: "{{ pve_kvm_VMID.stdout }}"
     state: started
-  delegate_to: "{{ pve_kvm_api_host }}"
+  delegate_to: "{{ pve_api_host }}"
   when: pve_kvm_start_after_create | bool
 
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   args:
     executable: /bin/bash
   delegate_to: "{{ pve_kvm_api_host }}"
-  register: VMID
+  register: pve_kvm_VMID
   when: pve_kvm_virtualm is succeeded
   changed_when: false
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,10 +5,10 @@
 - include_tasks: dependencies.yml
 
 - include_tasks: create_kvm.yml
-  when: not clone_from_existing | bool
+  when: not pve_kvm_clone_from_existing | bool
 
 - include_tasks: clone_kvm.yml
-  when: clone_from_existing | bool
+  when: pve_kvm_clone_from_existing | bool
 
 # Extraer el número de VM
 - name: Extract the ID of the VM
@@ -33,3 +33,5 @@
     state: started
   delegate_to: "{{ pve_kvm_api_host }}"
   when: pve_kvm_start_after_create | bool
+
+...


### PR DESCRIPTION
New clear namespace of variables' API and possibility to define `pve_hostname` as a variable. 

Equivalent for KVM of [this refactor for LXC](https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/pull/12).
