### PR TITLE
First use apt to check if proxmoxer is installed.

### DIFF
--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,16 +1,8 @@
 ---
 
-# Verificar si python-pip está instalado en el nodo Proxmox
-- name: Verify that python-pip is installed in the Proxmox node
+- name: Ensure that proxmoxer is installed
   ansible.builtin.apt:
-    name: python-pip
-    state: present
-  delegate_to: "{{ pve_api_host }}"
-
-# Verificar si el módulo proxmoxer de python está instalado
-- name: Verify if proxmoxer pip module is installed
-  ansible.builtin.pip:
-    name: proxmoxer
+    name: python3-proxmoxer
     state: present
   delegate_to: "{{ pve_api_host }}"
 


### PR DESCRIPTION
If proxmoxer is installed via apt don't use pip to check this
dependency.
Otherwise pip also becomes a dependency which is not needed for
community.general.proxmox_kvm.
#15 